### PR TITLE
yarnをglobalに入れる

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ From node:latest
 RUN apt-get update \
     && apt-get install --no-install-recommends -y rsync python python-pip build-essential libssl-dev libffi-dev python-dev \
     && apt-get clean \
-    && npm install -g node-gyp \
+    && npm install -g node-gyp yarn@1.6 \
     && pip install awscli


### PR DESCRIPTION
## 対応
- dockerでglobalにyarnのバージョン1.6(とりあえず固定)を入れるようにする